### PR TITLE
rework-exceptions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -33,6 +33,9 @@ jobs:
           runVcpkgInstall : true
 
         # Build and test in Debug
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.36
       - name: Build & Test in Debug
         run: |
           cmake --preset dev_clang_ninja
@@ -58,6 +61,8 @@ jobs:
 
         # Build and test in Release
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.36
       - name: Build & Test in Release
         run: |
           cmake --preset dev_vc143_ninja

--- a/cmake/SPARKCompilerFlags.cmake
+++ b/cmake/SPARKCompilerFlags.cmake
@@ -93,13 +93,19 @@ block()
             # Add support of addresses >= 2GB
             /LARGEADDRESSAWARE
         )
-    else() # Linux
+    else() # GCC or Clang
         # Compiler options
         target_compile_options(${_spark_compiler_linker_opt_target} INTERFACE
             # Enables all the warnings about constructions that some users consider questionable, and that are easy to avoid (or modify to prevent the warning), even in conjunction with macros.
             $<${_c_cxx_lang}:-Wall>
             -march=native
-        )
+        )        
+
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            target_compile_options(${_spark_compiler_linker_opt_target} INTERFACE
+                -D __cpp_consteval=1
+            )        
+        endif()
 
         # Define installation directories variables using GNU Standard.
         include(GNUInstallDirs)

--- a/experimental/ser/src/FileSerializer.cpp
+++ b/experimental/ser/src/FileSerializer.cpp
@@ -3,6 +3,7 @@
 #include "spark/base/Exception.h"
 
 #include <format>
+
 namespace spark::ser
 {
     FileSerializer::FileSerializer(const std::filesystem::path& filename, const bool is_reading)
@@ -10,10 +11,7 @@ namespace spark::ser
     {
         m_file.open(filename, isReading ? (std::fstream::in | std::fstream::binary) : (std::fstream::out | std::fstream::trunc | std::fstream::binary));
         if (!m_file.is_open())
-        {
-            const std::string error_message = std::format("Can't open file {0} for {1}", filename.string(), is_reading ? "reading" : "writing");
-            SPARK_BASE_THROW_EXCEPTION(spark::base::CouldNotOpenFileException, error_message.c_str());
-        }
+            throw spark::base::CouldNotOpenFileException(std::format("Can't open file {0} for {1}", filename.string(), is_reading ? "reading" : "writing"));
     }
 
     void FileSerializer::readImpl(char* dest, const std::streamsize size)

--- a/experimental/ser/src/MemorySerializer.cpp
+++ b/experimental/ser/src/MemorySerializer.cpp
@@ -20,10 +20,10 @@ namespace spark::ser
     void MemorySerializer::readImpl(char* dest, const std::size_t size)
     {
         if (!isReading)
-            SPARK_BASE_THROW_EXCEPTION(spark::base::WrongSerializerMode, "Can't read when in write mode");
+            throw spark::base::WrongSerializerMode("Can't read when in write mode");
 
         if (size + m_readOffset > m_data.size())
-            SPARK_BASE_THROW_EXCEPTION(spark::base::OverflowException, "Can't read past the end of the buffer");
+            throw spark::base::OverflowException("Can't read past the end of the buffer");
 
         std::memcpy(dest, &m_data[m_readOffset], size);
         m_readOffset += size;
@@ -32,7 +32,7 @@ namespace spark::ser
     void MemorySerializer::writeImpl(const char* src, const std::size_t size)
     {
         if (isReading)
-            SPARK_BASE_THROW_EXCEPTION(spark::base::WrongSerializerMode, "Can't write when in read mode");
+            throw spark::base::WrongSerializerMode("Can't write when in read mode");
 
         const std::size_t offset = m_data.size();
         m_data.resize(offset + size);

--- a/spark/audio/src/Sound.cpp
+++ b/spark/audio/src/Sound.cpp
@@ -11,10 +11,10 @@ namespace spark::audio
     Sound::Sound(const std::filesystem::path& file)
     {
         if (std::ranges::find(supportedExtensions, file.extension()) == supportedExtensions.end())
-            SPARK_BASE_THROW_EXCEPTION(base::UnsupportedFileFormatException, std::format("Unsupported file format: {}", file.extension().generic_string()).c_str());
+            throw base::UnsupportedFileFormatException(std::format("Unsupported file format: {}", file.extension().generic_string()));
 
         if (!m_buffer.loadFromFile(file.generic_string()))
-            SPARK_BASE_THROW_EXCEPTION(base::CouldNotOpenFileException, std::format("Could not open file: {}", file.generic_string()).c_str());
+            throw base::CouldNotOpenFileException(std::format("Could not open file: {}", file.generic_string()));
         m_sound.setBuffer(m_buffer);
     }
 

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -4,20 +4,18 @@
 #include "spark/base/Macros.h"
 #include "spark/base/details/Exception.h"
 
-#include <format>
 #include <source_location>
-#include <stdexcept>
 
 /**
 * \brief Macro used to define and implement a derived exception class.
 * \param DerivedClass The name of the derived exception to create.
 */
 #define SPARK_BASE_DEFINE_EXCEPTION(DerivedClass)                                                                           \
-    class SPARK_BASE_EXPORT DerivedClass : public spark::base::Exception                                                    \
+    class SPARK_BASE_EXPORT DerivedClass : public spark::base::details::Exception                                           \
     {                                                                                                                       \
     public:                                                                                                                 \
         DerivedClass(const char* message, const std::source_location& source_location = std::source_location::current())    \
-            : base::Exception(typeid(DerivedClass).name(), message, source_location)                                        \
+            : base::details::Exception(typeid(DerivedClass).name(), message, source_location)                               \
         {}                                                                                                                  \
     };
 
@@ -28,38 +26,6 @@
 
 namespace spark::base
 {
-    SPARK_WARNING_PUSH
-    SPARK_DISABLE_MSVC_WARNING(4275) // non dll-interface class used as base for dll-interface class -> disabled since class is an stl class
-
-    /**
-     * \brief The base class for all exceptions in Spark. Should be used as a base class only.
-     */
-    class SPARK_BASE_EXPORT Exception : public std::runtime_error
-    {
-    public:
-        explicit Exception(const char* class_name, const char* message, const std::source_location& source_location)
-            : std::runtime_error(FormatMessage(class_name, message, source_location).c_str()) {}
-
-        ~Exception() override = default;
-
-        Exception(const Exception& other) = default;
-        Exception(Exception&& other) noexcept = default;
-        Exception& operator=(const Exception& other) = default;
-        Exception& operator=(Exception&& other) noexcept = default;
-
-    protected:
-        static std::string FormatMessage(const char* class_name, const char* message, const std::source_location& source_location)
-        {
-            return std::format("Exception of type {0} has been thrown.\nError happen in {1}:{2}.\nException contains the message:\n{3}",
-                               class_name,
-                               source_location.file_name(),
-                               source_location.line(),
-                               message);
-        }
-    };
-
-    SPARK_WARNING_POP
-
     /**
      * \brief Exception thrown when an argument does not have the expected type.
      */

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -19,11 +19,6 @@
         {}                                                                                                                              \
     };
 
-/**
- * \brief The macro used to throw a spark exception.
- */
-#define SPARK_BASE_THROW_EXCEPTION(...) SPARK_BASE_DETAILS_THROW_EXCEPTION_MACRO_CHOOSER(__VA_ARGS__)
-
 namespace spark::base
 {
     /**

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -32,16 +32,6 @@ namespace spark::base
     SPARK_BASE_DEFINE_EXCEPTION(BadArgumentException)
 
     /**
-     * \brief Exception thrown when a parameter already exist.
-     */
-    SPARK_BASE_DEFINE_EXCEPTION(DuplicatedParameterException)
-
-    /**
-     * \brief Exception thrown when a parameter is missing.
-     */
-    SPARK_BASE_DEFINE_EXCEPTION(CouldNotFindParameterException)
-
-    /**
      * \brief Exception thrown when a functionality which is not implemented yet is called.
      */
     SPARK_BASE_DEFINE_EXCEPTION(NotImplementedException)

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -5,19 +5,20 @@
 #include "spark/base/details/Exception.h"
 
 #include <format>
+#include <source_location>
 #include <stdexcept>
 
 /**
 * \brief Macro used to define and implement a derived exception class.
 * \param DerivedClass The name of the derived exception to create.
 */
-#define SPARK_BASE_DEFINE_EXCEPTION(DerivedClass)                                                               \
-    class SPARK_BASE_EXPORT DerivedClass : public spark::base::Exception                                        \
-    {                                                                                                           \
-    public:                                                                                                     \
-        DerivedClass(const char* file_name, const int line_number, const char* additional_message)              \
-            : base::Exception(file_name, line_number, additional_message, typeid(DerivedClass).name())   \
-        {}                                                                                                      \
+#define SPARK_BASE_DEFINE_EXCEPTION(DerivedClass)                                                                           \
+    class SPARK_BASE_EXPORT DerivedClass : public spark::base::Exception                                                    \
+    {                                                                                                                       \
+    public:                                                                                                                 \
+        DerivedClass(const char* message, const std::source_location& source_location = std::source_location::current())    \
+            : base::Exception(typeid(DerivedClass).name(), message, source_location)                                        \
+        {}                                                                                                                  \
     };
 
 /**
@@ -36,8 +37,8 @@ namespace spark::base
     class SPARK_BASE_EXPORT Exception : public std::runtime_error
     {
     public:
-        explicit Exception(const char* file_name, const int line_number, const char* additional_message, const char* class_name)
-            : std::runtime_error(FormatMessage(file_name, line_number, additional_message, class_name).c_str()) {}
+        explicit Exception(const char* class_name, const char* message, const std::source_location& source_location)
+            : std::runtime_error(FormatMessage(class_name, message, source_location).c_str()) {}
 
         ~Exception() override = default;
 
@@ -47,13 +48,13 @@ namespace spark::base
         Exception& operator=(Exception&& other) noexcept = default;
 
     protected:
-        static std::string FormatMessage(const char* file_name, const int line_number, const char* additional_message, const char* class_name)
+        static std::string FormatMessage(const char* class_name, const char* message, const std::source_location& source_location)
         {
-            return std::format("Exception of type {0} has been thrown.\nError happen in {1} at line number {2}.\nException contains the message:\n{3}",
+            return std::format("Exception of type {0} has been thrown.\nError happen in {1}:{2}.\nException contains the message:\n{3}",
                                class_name,
-                               file_name,
-                               line_number,
-                               additional_message);
+                               source_location.file_name(),
+                               source_location.line(),
+                               message);
         }
     };
 

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -15,7 +15,7 @@
     {                                                                                                                                   \
     public:                                                                                                                             \
         DerivedClass(const std::string_view& message, const std::source_location& source_location = std::source_location::current())    \
-            : base::details::Exception(typeid(DerivedClass).name(), message, source_location)                                           \
+            : base::details::Exception(#DerivedClass, message, source_location)                                                         \
         {}                                                                                                                              \
     };
 

--- a/spark/base/include/spark/base/Exception.h
+++ b/spark/base/include/spark/base/Exception.h
@@ -10,13 +10,13 @@
 * \brief Macro used to define and implement a derived exception class.
 * \param DerivedClass The name of the derived exception to create.
 */
-#define SPARK_BASE_DEFINE_EXCEPTION(DerivedClass)                                                                           \
-    class SPARK_BASE_EXPORT DerivedClass : public spark::base::details::Exception                                           \
-    {                                                                                                                       \
-    public:                                                                                                                 \
-        DerivedClass(const char* message, const std::source_location& source_location = std::source_location::current())    \
-            : base::details::Exception(typeid(DerivedClass).name(), message, source_location)                               \
-        {}                                                                                                                  \
+#define SPARK_BASE_DEFINE_EXCEPTION(DerivedClass)                                                                                       \
+    class SPARK_BASE_EXPORT DerivedClass : public spark::base::details::Exception                                                       \
+    {                                                                                                                                   \
+    public:                                                                                                                             \
+        DerivedClass(const std::string_view& message, const std::source_location& source_location = std::source_location::current())    \
+            : base::details::Exception(typeid(DerivedClass).name(), message, source_location)                                           \
+        {}                                                                                                                              \
     };
 
 /**

--- a/spark/base/include/spark/base/details/Exception.h
+++ b/spark/base/include/spark/base/details/Exception.h
@@ -4,30 +4,6 @@
 #include <source_location>
 #include <stdexcept>
 
-#define SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, additionalMessage) throw ExceptionType(additionalMessage)
-#define SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG(ExceptionType)                    SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, nullptr)
-#define SPARK_BASE_DETAILS_GET_3_TH_ARG(arg1, arg2, arg3, ...)                     arg3
-#define SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET(argsWithParenthesis)                SPARK_BASE_DETAILS_GET_3_TH_ARG argsWithParenthesis
-
-/**
- * \brief The macro used to select the right throw exception macro.
-
- * If there is only one argument, it expands to \ref SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG since __VA_ARGS__ length is 1.
- * \code
- * // Example with "AnyException" as argument:
- * SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET((AnyException, SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG, SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG)) AnyException
- * // The third argument in the set is SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG
- * \endcode
- *
- * If there is two arguments, it expands to \ref SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG since __VA_ARGS__ length is 2.
- * \code
- * // Example with "AnyException" as argument:
- * SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET((AnyException, SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG, SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG)) AnyException
- * // The third argument in the set is now SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG
- * \endcode
- */
-#define SPARK_BASE_DETAILS_THROW_EXCEPTION_MACRO_CHOOSER(...) SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET((__VA_ARGS__, SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG, SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG)) (__VA_ARGS__)
-
 SPARK_WARNING_PUSH
 SPARK_DISABLE_MSVC_WARNING(4275) // non dll-interface class used as base for dll-interface class -> disabled since class is an stl class
 

--- a/spark/base/include/spark/base/details/Exception.h
+++ b/spark/base/include/spark/base/details/Exception.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, additionalMessage) throw ExceptionType(__FILE__, __LINE__, additionalMessage)
+#define SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, additionalMessage) throw ExceptionType(additionalMessage)
 #define SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG(ExceptionType)                    SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, nullptr)
 #define SPARK_BASE_DETAILS_GET_3_TH_ARG(arg1, arg2, arg3, ...)                     arg3
 #define SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET(argsWithParenthesis)                SPARK_BASE_DETAILS_GET_3_TH_ARG argsWithParenthesis

--- a/spark/base/include/spark/base/details/Exception.h
+++ b/spark/base/include/spark/base/details/Exception.h
@@ -39,7 +39,7 @@ namespace spark::base::details
     class SPARK_BASE_EXPORT Exception : public std::runtime_error
     {
     public:
-        explicit Exception(const char* class_name, const char* message, const std::source_location& source_location)
+        explicit Exception(const char* class_name, const std::string_view& message, const std::source_location& source_location)
             : std::runtime_error(FormatMessage(class_name, message, source_location).c_str()) {}
 
         ~Exception() override = default;
@@ -50,7 +50,7 @@ namespace spark::base::details
         Exception& operator=(Exception&& other) noexcept = default;
 
     protected:
-        static std::string FormatMessage(const char* class_name, const char* message, const std::source_location& source_location)
+        static std::string FormatMessage(const char* class_name, const std::string_view& message, const std::source_location& source_location)
         {
             return std::format("Exception of type {0} has been thrown.\nError happen in {1}:{2}.\nException contains the message:\n{3}",
                                class_name,

--- a/spark/base/include/spark/base/details/Exception.h
+++ b/spark/base/include/spark/base/details/Exception.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <format>
+#include <source_location>
+#include <stdexcept>
+
 #define SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, additionalMessage) throw ExceptionType(additionalMessage)
 #define SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG(ExceptionType)                    SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG(ExceptionType, nullptr)
 #define SPARK_BASE_DETAILS_GET_3_TH_ARG(arg1, arg2, arg3, ...)                     arg3
@@ -23,3 +27,38 @@
  * \endcode
  */
 #define SPARK_BASE_DETAILS_THROW_EXCEPTION_MACRO_CHOOSER(...) SPARK_BASE_DETAILS_GET_3_TH_ARG_IN_SET((__VA_ARGS__, SPARK_BASE_DETAILS_THROW_EXCEPTION_2_ARG, SPARK_BASE_DETAILS_THROW_EXCEPTION_1_ARG)) (__VA_ARGS__)
+
+SPARK_WARNING_PUSH
+SPARK_DISABLE_MSVC_WARNING(4275) // non dll-interface class used as base for dll-interface class -> disabled since class is an stl class
+
+namespace spark::base::details
+{
+    /**
+     * \brief The base class for all exceptions in Spark. Should be used as a base class only.
+     */
+    class SPARK_BASE_EXPORT Exception : public std::runtime_error
+    {
+    public:
+        explicit Exception(const char* class_name, const char* message, const std::source_location& source_location)
+            : std::runtime_error(FormatMessage(class_name, message, source_location).c_str()) {}
+
+        ~Exception() override = default;
+
+        Exception(const Exception& other) = default;
+        Exception(Exception&& other) noexcept = default;
+        Exception& operator=(const Exception& other) = default;
+        Exception& operator=(Exception&& other) noexcept = default;
+
+    protected:
+        static std::string FormatMessage(const char* class_name, const char* message, const std::source_location& source_location)
+        {
+            return std::format("Exception of type {0} has been thrown.\nError happen in {1}:{2}.\nException contains the message:\n{3}",
+                               class_name,
+                               source_location.file_name(),
+                               source_location.line(),
+                               message);
+        }
+    };
+}
+
+SPARK_WARNING_POP

--- a/spark/core/src/SceneManager.cpp
+++ b/spark/core/src/SceneManager.cpp
@@ -10,14 +10,14 @@ namespace spark::core
     void SceneManager::RegisterScene(std::string name, std::unique_ptr<engine::Scene> scene)
     {
         if (s_scenes.contains(name))
-            SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Can't register 2 scenes with the same name");
+            throw base::UnknownException("Can't register 2 scenes with the same name");
         s_scenes.emplace(std::move(name), std::move(scene));
     }
 
     void SceneManager::UnregisterScene(const std::string& name)
     {
         if (!s_scenes.contains(name))
-            SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Can't unregister a not registered scene");
+            throw base::UnknownException("Can't unregister a not registered scene");
         s_scenes.erase(name);
     }
 
@@ -25,7 +25,7 @@ namespace spark::core
     {
         // TODO: Allow a loaded scene to be loaded multiple times without seeing the modifications made in the previous runtime.
         if (!s_scenes.contains(name))
-            SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Can't load a not registered scene");
+            throw base::UnknownException("Can't load a not registered scene");
         Application::Instance()->setScene(s_scenes.at(name));
     }
 
@@ -34,7 +34,7 @@ namespace spark::core
         if (!s_scenes.contains(name))
         {
             if (fail)
-                SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Can't get a not registered scene");
+                throw base::UnknownException("Can't get a not registered scene");
             return nullptr;
         }
         return s_scenes.at(name);

--- a/spark/engine/src/Component.cpp
+++ b/spark/engine/src/Component.cpp
@@ -7,7 +7,7 @@ namespace spark::engine
         : m_gameObject(parent)
     {
         if (!parent)
-            SPARK_BASE_THROW_EXCEPTION(base::BadArgumentException, "Cannot create a component with a null parent GameObject");
+            throw base::BadArgumentException("Cannot create a component with a null parent GameObject");
     }
 
     const lib::Uuid& Component::getUuid() const

--- a/spark/engine/src/GameObject.cpp
+++ b/spark/engine/src/GameObject.cpp
@@ -28,7 +28,7 @@ namespace spark::engine
             if (obj->getUuid() == uuid)
             {
                 if (found != nullptr)
-                    SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Found multiple GameObjects with the same UUID!");
+                    throw base::UnknownException("Found multiple GameObjects with the same UUID!");
                 found = obj;
             }
         });
@@ -43,7 +43,7 @@ namespace spark::engine
             if (obj->getName() == name)
             {
                 if (found != nullptr)
-                    SPARK_BASE_THROW_EXCEPTION(base::UnknownException, "Found multiple GameObjects with the same name!");
+                    throw base::UnknownException("Found multiple GameObjects with the same name!");
                 found = obj;
             }
         });
@@ -94,7 +94,7 @@ namespace spark::engine
     void GameObject::addComponent(Component* component, bool managed)
     {
         if (m_components.contains(&component->getRttiInstance()))
-            SPARK_BASE_THROW_EXCEPTION(base::BadArgumentException, "Unable to add the same component twice!");
+            throw base::BadArgumentException("Unable to add the same component twice!");
 
         m_components.insert({&component->getRttiInstance(), {component, managed}});
         if (m_initialized)
@@ -104,7 +104,7 @@ namespace spark::engine
     void GameObject::removeComponent(Component* component)
     {
         if (!m_components.contains(&component->getRttiInstance()))
-            SPARK_BASE_THROW_EXCEPTION(base::BadArgumentException, "Unable to remove a non-existing component!");
+            throw base::BadArgumentException("Unable to remove a non-existing component!");
 
         m_components.erase(&component->getRttiInstance());
         component->onDetach();

--- a/spark/patterns/include/spark/patterns/impl/Composite.h
+++ b/spark/patterns/include/spark/patterns/impl/Composite.h
@@ -112,7 +112,7 @@ namespace spark::patterns
     {
         auto it = std::ranges::find(m_children, child);
         if (it != m_children.end())
-            SPARK_BASE_THROW_EXCEPTION(spark::base::BadArgumentException, "Child already exists in the children list!");
+            throw spark::base::BadArgumentException("Child already exists in the children list!");
         m_children.push_back(child);
     }
 
@@ -121,7 +121,7 @@ namespace spark::patterns
     {
         const auto it = std::ranges::find(m_children, child);
         if (it == m_children.end())
-            SPARK_BASE_THROW_EXCEPTION(spark::base::BadArgumentException, "Child could not be found in the children list!");
+            throw spark::base::BadArgumentException("Child could not be found in the children list!");
         m_children.erase(it);
     }
 }

--- a/spark/patterns/include/spark/patterns/impl/Factory.h
+++ b/spark/patterns/include/spark/patterns/impl/Factory.h
@@ -11,7 +11,7 @@ namespace spark::patterns
     void Factory<Key, BaseType, Args...>::registerType(const Key& key)
     {
         if (m_creators.contains(key))
-            SPARK_BASE_THROW_EXCEPTION(spark::base::DuplicatedParameterException, "Type is already registered into the factory.");
+            throw spark::base::DuplicatedParameterException("Type is already registered into the factory.");
         m_creators[key] = std::make_unique<details::DerivedCreator<BaseType, TypeToRegister, Args...>>();
     }
 
@@ -19,7 +19,7 @@ namespace spark::patterns
     typename Factory<Key, BaseType, Args...>::BasePtr Factory<Key, BaseType, Args...>::create(const Key& key, const Args&... args) const
     {
         if (!m_creators.contains(key))
-            SPARK_BASE_THROW_EXCEPTION(spark::base::CouldNotFindParameterException, "Type is not registered into the factory.");
+            throw spark::base::CouldNotFindParameterException("Type is not registered into the factory.");
         return m_creators.at(key)->create(args...);
     }
 

--- a/spark/patterns/include/spark/patterns/impl/Factory.h
+++ b/spark/patterns/include/spark/patterns/impl/Factory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "spark/patterns/details/Creators.h"
 
 #include "spark/base/Exception.h"
@@ -11,7 +13,7 @@ namespace spark::patterns
     void Factory<Key, BaseType, Args...>::registerType(const Key& key)
     {
         if (m_creators.contains(key))
-            throw spark::base::DuplicatedParameterException("Type is already registered into the factory.");
+            throw spark::base::BadArgumentException("Type is already registered into the factory.");
         m_creators[key] = std::make_unique<details::DerivedCreator<BaseType, TypeToRegister, Args...>>();
     }
 
@@ -19,7 +21,7 @@ namespace spark::patterns
     typename Factory<Key, BaseType, Args...>::BasePtr Factory<Key, BaseType, Args...>::create(const Key& key, const Args&... args) const
     {
         if (!m_creators.contains(key))
-            throw spark::base::CouldNotFindParameterException("Type is not registered into the factory.");
+            throw spark::base::BadArgumentException("Type is not registered into the factory.");
         return m_creators.at(key)->create(args...);
     }
 


### PR DESCRIPTION
## Pull Request Template - Spark 

### Description
Rework the exceptions throwing and creation in SPARK.

### Related Issue
Closes #32

### Proposed Changes
- Use `std::source_location` instead of macros to print the exception file and line
- Move base exception class to details
- Remove helper macro to throw an exception
- Remove misused exception types