### PR TITLE
gameobject-crtp

### DIFF
--- a/examples/pong/include/pong/Ball.h
+++ b/examples/pong/include/pong/Ball.h
@@ -35,8 +35,6 @@ namespace pong
 
         void onSpawn() override
         {
-            GameObject::onSpawn();
-
             // Find the paddles.
             m_leftPaddle = FindByName(getRoot(), "Left Paddle");
             SPARK_ASSERT(m_leftPaddle != nullptr)
@@ -59,8 +57,6 @@ namespace pong
 
         void onUpdate(const float dt) override
         {
-            GameObject::onUpdate(dt);
-
             const auto [next_position, next_direction] = calculateNextFrame(getTransform()->position + direction * velocity * dt);
             if (checkLoose(next_position))
                 onLoose.emit();

--- a/examples/pong/include/pong/GameManager.h
+++ b/examples/pong/include/pong/GameManager.h
@@ -29,8 +29,6 @@ namespace pong
 
         void onSpawn() override
         {
-            GameObject::onSpawn();
-
             m_leftPaddle = FindByName(getRoot(), "Left Paddle");
             m_rightPaddle = FindByName(getRoot(), "Right Paddle");
             m_ball = dynamic_cast<Ball*>(FindByName(getRoot(), "Ball"));
@@ -53,8 +51,6 @@ namespace pong
 
         void onUpdate(const float dt) override
         {
-            GameObject::onUpdate(dt);
-
             // Left paddle
             if (spark::core::Input::IsKeyPressed(spark::base::KeyCodes::Z))
             {
@@ -90,8 +86,6 @@ namespace pong
 
         void onDestroyed() override
         {
-            GameObject::onDestroyed();
-
             m_ball->onLoose.disconnect(m_looseSlotKey);
             m_menuSound.stop();
         }

--- a/examples/pong/include/pong/ui/Background.h
+++ b/examples/pong/include/pong/ui/Background.h
@@ -25,8 +25,6 @@ namespace pong::ui
 
         void render() const override
         {
-            Component::render();
-
             const auto window_size = spark::core::Application::Instance()->getWindow().getSize().castTo<std::size_t>();
 
             for (std::size_t i = 0; i < window_size.y / (lineLength + verticalOffset); i++)
@@ -56,8 +54,6 @@ namespace pong::ui
 
         void render() const override
         {
-            Component::render();
-
             const auto score = std::to_string(m_currentScore);
             spark::core::Renderer2D::DrawText(score, m_position, 100, spark::path::assets_path() / "font.ttf");
         }

--- a/examples/pong/include/pong/ui/Menu.h
+++ b/examples/pong/include/pong/ui/Menu.h
@@ -37,8 +37,6 @@ namespace pong::ui
 
         void onSpawn() override
         {
-            GameObject::onSpawn();
-
             m_playButtonSlotId = m_playButton->onClicked.connect([]
             {
                 spark::core::SceneManager::LoadScene("Game");
@@ -51,8 +49,6 @@ namespace pong::ui
 
         void onDestroyed() override
         {
-            GameObject::onDestroyed();
-
             m_playButton->onClicked.disconnect(m_playButtonSlotId);
             m_quitButton->onClicked.disconnect(m_quitButtonSlotId);
         }

--- a/spark/engine/CMakeLists.txt
+++ b/spark/engine/CMakeLists.txt
@@ -20,7 +20,10 @@ spark_add_library(${TARGET_NAME}
         ${HEADER_DIR}/${SPARK_NAME}/engine/components/Text.h
         ${HEADER_DIR}/${SPARK_NAME}/engine/components/Transform.h
 
-        ${HEADER_DIR}/${SPARK_NAME}/engine/impl/GameObject.h)
+        ${HEADER_DIR}/${SPARK_NAME}/engine/details/AbstractGameObject.h
+        ${HEADER_DIR}/${SPARK_NAME}/engine/impl/AbstractGameObject.h
+        ${HEADER_DIR}/${SPARK_NAME}/engine/impl/GameObject.h
+)
 
 target_link_libraries(${TARGET_NAME}
 	PUBLIC

--- a/spark/engine/include/spark/engine/GameObject.h
+++ b/spark/engine/include/spark/engine/GameObject.h
@@ -2,9 +2,9 @@
 
 #include "spark/engine/Component.h"
 #include "spark/engine/Export.h"
+#include "spark/engine/details/AbstractGameObject.h"
 
 #include "spark/base/Macros.h"
-#include "spark/patterns/Composite.h"
 #include "spark/rtti/HasRtti.h"
 
 namespace spark::engine::components
@@ -19,7 +19,7 @@ namespace spark::engine
      *
      * GameObjects can be parented to other GameObjects. When a GameObject is destroyed, all its children are destroyed as well with their components.
      */
-    class SPARK_ENGINE_EXPORT GameObject : public rtti::HasRtti, public patterns::Composite<GameObject>
+    class SPARK_ENGINE_EXPORT GameObject : public rtti::HasRtti, public details::AbstractGameObject<GameObject>
     {
         DECLARE_SPARK_RTTI(GameObject)
 
@@ -165,18 +165,18 @@ namespace spark::engine
         /**
          * \brief Method called when the GameObject is spawned in the scene.
          */
-        virtual void onSpawn();
+        virtual void onSpawn() {}
 
         /**
          * \brief Method called on every frame.
          * \param dt The time in seconds since the last frame.
          */
-        virtual void onUpdate(float dt);
+        virtual void onUpdate(float dt) { SPARK_UNUSED(dt); }
 
         /**
          * \brief Method called when the GameObject is destroyed.
          */
-        virtual void onDestroyed();
+        virtual void onDestroyed() {}
 
     public:
         /**
@@ -197,8 +197,6 @@ namespace spark::engine
     private:
         lib::Uuid m_uuid;
         std::string m_name;
-        bool m_initialized = false;
-        std::unordered_map<rtti::RttiBase*, std::pair<Component*, bool>> m_components;
     };
 }
 

--- a/spark/engine/include/spark/engine/details/AbstractGameObject.h
+++ b/spark/engine/include/spark/engine/details/AbstractGameObject.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "spark/patterns/Composite.h"
+
+namespace spark::engine
+{
+    class GameObject;
+}
+
+namespace spark::engine::details
+{
+    /**
+     * \brief A CRTP class to implement a GameObject. It is used to wrap the onSpawn, onUpdate and onDestroyed methods to include custom code around user implementation.
+     * \tparam Impl The implementation of the GameObject.
+     */
+    template <typename Impl>
+    class AbstractGameObject : public patterns::Composite<GameObject>
+    {
+        friend class spark::engine::GameObject;
+
+    public:
+        explicit AbstractGameObject(GameObject* parent = nullptr);
+        ~AbstractGameObject() override;
+
+        AbstractGameObject(const AbstractGameObject& other) = delete;
+        AbstractGameObject(AbstractGameObject&& other) noexcept = default;
+        AbstractGameObject& operator=(const AbstractGameObject& other) = delete;
+        AbstractGameObject& operator=(AbstractGameObject&& other) noexcept = default;
+
+        /**
+         * \brief Method calling the corresponding method on the implementation, the children and components.
+         */
+        void onSpawn();
+
+        /**
+         * \brief Method calling the corresponding method on the implementation, the children and components.
+         * \param dt The time in seconds since the last frame.
+         */
+        void onUpdate(float dt);
+
+        /**
+         * \brief Method calling the corresponding method on the implementation, the children and components.
+         */
+        void onDestroyed();
+
+    private:
+        bool m_initialized = false;
+        std::unordered_map<rtti::RttiBase*, std::pair<Component*, bool>> m_components;
+    };
+}
+
+#include "spark/engine/impl/AbstractGameObject.h"

--- a/spark/engine/include/spark/engine/impl/AbstractGameObject.h
+++ b/spark/engine/include/spark/engine/impl/AbstractGameObject.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <algorithm>
+#include <ranges>
+
+namespace spark::engine::details
+{
+    template<typename Impl>
+    AbstractGameObject<Impl>::AbstractGameObject(GameObject* parent)
+        : Composite(parent)
+    {
+    }
+
+    template<typename Impl>
+    AbstractGameObject<Impl>::~AbstractGameObject()
+    {
+        // Ensure onDestroyed() was called
+        SPARK_CORE_ASSERT(!m_initialized)
+
+        for (const auto& [component, managed] : m_components | std::views::values)
+            if (managed)
+                delete component;
+    }
+
+    template <typename Impl>
+    void AbstractGameObject<Impl>::onSpawn()
+    {
+        SPARK_CORE_ASSERT(!m_initialized)
+        static_cast<Impl*>(this)->onSpawn();
+        std::ranges::for_each(m_components | std::views::values | std::views::keys,
+                              [](Component* component)
+                              {
+                                  component->onAttach();
+                              });
+        m_initialized = true;
+    }
+
+    template <typename Impl>
+    void AbstractGameObject<Impl>::onUpdate(float dt)
+    {
+        static_cast<Impl*>(this)->onUpdate(dt);
+        std::ranges::for_each(m_components | std::views::values | std::views::keys,
+                              [&dt](Component* component)
+                              {
+                                  component->onUpdate(dt);
+                              });
+    }
+
+    template <typename Impl>
+    void AbstractGameObject<Impl>::onDestroyed()
+    {
+        SPARK_CORE_ASSERT(m_initialized)
+        std::ranges::for_each(m_components | std::views::values | std::views::keys,
+                              [](Component* component)
+                              {
+                                  component->onDetach();
+                              });
+        static_cast<Impl*>(this)->onDestroyed();
+        m_initialized = false;
+    }
+}

--- a/spark/engine/src/Scene.cpp
+++ b/spark/engine/src/Scene.cpp
@@ -29,7 +29,7 @@ namespace spark::engine
             return;
 
         SPARK_CORE_INFO("Loading scene {}", getUuid().str());
-        getRoot()->traverse([](GameObject* object)
+        getRoot()->traverse([](details::AbstractGameObject<GameObject>* object)
         {
             object->onSpawn();
         });
@@ -38,7 +38,7 @@ namespace spark::engine
 
     void Scene::onUpdate(float dt)
     {
-        getRoot()->traverse([&dt](GameObject* object)
+        getRoot()->traverse([&dt](details::AbstractGameObject<GameObject>* object)
         {
             object->onUpdate(dt);
         });
@@ -50,7 +50,7 @@ namespace spark::engine
             return;
 
         SPARK_CORE_INFO("Unloading scene {}", getUuid().str());
-        getRoot()->traverse([](GameObject* object)
+        getRoot()->traverse([](details::AbstractGameObject<GameObject>* object)
         {
             object->onDestroyed();
         });


### PR DESCRIPTION
## Pull Request Template - Spark 

### Description
Removes the need to call parent functions when creating custom GameObjects.

### Related Issue
Closes #10 

### Proposed Changes
Add a CRTP class AbstractGameObject which calls the virtual method in the GameObject class surrounded by our internal code in order.