### PR TITLE
traverser

### DIFF
--- a/spark/engine/include/spark/engine/components/Transform.h
+++ b/spark/engine/include/spark/engine/components/Transform.h
@@ -22,10 +22,13 @@ namespace spark::engine::components
         static math::Vector2<float> LocalToWorld(const Transform* object)
         {
             math::Vector2<float> position = {};
-            object->getGameObject()->traverseUp([&position](const GameObject* parent)
+
+            auto* game_object = object->getGameObject();
+            while (game_object->getParent() != nullptr)
             {
-                position += parent->getTransform()->position;
-            });
+                position += game_object->getTransform()->position;
+                game_object = game_object->getParent();
+            }
             return position;
         }
 

--- a/spark/engine/src/Scene.cpp
+++ b/spark/engine/src/Scene.cpp
@@ -1,6 +1,7 @@
 #include "spark/engine/Scene.h"
 
 #include "spark/log/Logger.h"
+#include "spark/patterns/Traverser.h"
 
 namespace spark::engine
 {
@@ -29,19 +30,23 @@ namespace spark::engine
             return;
 
         SPARK_CORE_INFO("Loading scene {}", getUuid().str());
-        getRoot()->traverse([](details::AbstractGameObject<GameObject>* object)
+
+        auto traverser = spark::patterns::make_traverser<GameObject>([](auto* object)
         {
-            object->onSpawn();
+            static_cast<details::AbstractGameObject<GameObject>*>(object)->onSpawn();
         });
+        spark::patterns::traverse_tree(m_root, traverser);
+
         m_isLoaded = true;
     }
 
     void Scene::onUpdate(float dt)
     {
-        getRoot()->traverse([&dt](details::AbstractGameObject<GameObject>* object)
+        auto traverser = spark::patterns::make_traverser<GameObject>([&dt](auto* object)
         {
-            object->onUpdate(dt);
+            static_cast<details::AbstractGameObject<GameObject>*>(object)->onUpdate(dt);
         });
+        spark::patterns::traverse_tree(m_root, traverser);
     }
 
     void Scene::onUnload()
@@ -50,10 +55,13 @@ namespace spark::engine
             return;
 
         SPARK_CORE_INFO("Unloading scene {}", getUuid().str());
-        getRoot()->traverse([](details::AbstractGameObject<GameObject>* object)
+
+        auto traverser = spark::patterns::make_traverser<GameObject>([](auto* object)
         {
-            object->onDestroyed();
+            static_cast<details::AbstractGameObject<GameObject>*>(object)->onDestroyed();
         });
+        spark::patterns::traverse_tree(m_root, traverser);
+
         m_isLoaded = false;
         SPARK_CORE_INFO("Scene {} unloaded", getUuid().str());
     }

--- a/spark/patterns/CMakeLists.txt
+++ b/spark/patterns/CMakeLists.txt
@@ -9,9 +9,11 @@ spark_add_library(${TARGET_NAME} INTERFACE
         ${HEADER_DIR}/${SPARK_NAME}/patterns/Factory.h
         ${HEADER_DIR}/${SPARK_NAME}/patterns/Signal.h
         ${HEADER_DIR}/${SPARK_NAME}/patterns/Slot.h
+        ${HEADER_DIR}/${SPARK_NAME}/patterns/Traverser.h
 
         ${HEADER_DIR}/${SPARK_NAME}/patterns/details/Connection.h
         ${HEADER_DIR}/${SPARK_NAME}/patterns/details/Creators.h
+        ${HEADER_DIR}/${SPARK_NAME}/patterns/details/Traverser.h
 
         ${HEADER_DIR}/${SPARK_NAME}/patterns/impl/Composite.h
         ${HEADER_DIR}/${SPARK_NAME}/patterns/impl/Factory.h

--- a/spark/patterns/include/spark/patterns/Composite.h
+++ b/spark/patterns/include/spark/patterns/Composite.h
@@ -25,12 +25,6 @@ namespace spark::patterns
         [[nodiscard]] DerivedType* getRoot();
         [[nodiscard]] const DerivedType* getRoot() const;
 
-        void traverse(std::function<void(DerivedType*)> fn);
-        void traverse(std::function<void(const DerivedType*)> fn) const;
-
-        void traverseUp(std::function<void(DerivedType*)> fn);
-        void traverseUp(std::function<void(const DerivedType*)> fn) const;
-
     private:
         void add(DerivedType* child);
         void remove(DerivedType* child);

--- a/spark/patterns/include/spark/patterns/Traverser.h
+++ b/spark/patterns/include/spark/patterns/Traverser.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "spark/patterns/Composite.h"
+#include "spark/patterns/details/Traverser.h"
+
+#include <functional>
+
+namespace spark::patterns
+{
+    /**
+     * @brief A base class for any traverser used by the @ref traverse_tree function.
+     * @tparam NodeType Type of the nodes of the tree.
+     * @tparam FnArgsTypes The types of arguments that will be passed to the pre/post/apply functions.
+     */
+    template <typename NodeType, typename... FnArgsTypes>
+    class Traverser
+    {
+    public:
+        using FnType = std::function<void(NodeType*, FnArgsTypes&&...)>;
+
+        explicit Traverser(FnType apply, FnType pre = {}, FnType post = {})
+            : m_pre(std::move(pre)), m_apply(std::move(apply)), m_post(std::move(post)) {}
+
+        void apply(NodeType* child, FnArgsTypes&&... args)
+        {
+            if (!m_apply)
+                return;
+            std::invoke(m_apply, child, std::forward<FnArgsTypes>(args)...);
+        }
+
+        void pre(NodeType* child, FnArgsTypes&&... args)
+        {
+            if (!m_pre)
+                return;
+            std::invoke(m_pre, child, std::forward<FnArgsTypes>(args)...);
+        }
+
+        void post(NodeType* child, FnArgsTypes&&... args)
+        {
+            if (!m_post)
+                return;
+            std::invoke(m_post, child, std::forward<FnArgsTypes>(args)...);
+        }
+
+    private:
+        FnType m_pre, m_apply, m_post;
+    };
+
+    /**
+     * @brief A helper function to create a traverser from functions.
+     * The apply function is called on every element of the tree except the root, while the pre/post functions are called only on the elements that can have children (except the root).
+     *
+     * @tparam NodeType Type of the nodes of the tree.
+     * @tparam FnArgsTypes The types of arguments that will be passed to the pre/post/apply functions.
+     * @param apply The function to call on every element of the tree except the root.
+     * @param pre The function to call on every element of the tree that can have children before traversing its children (except the root).
+     * @param post The function to call on every element of the tree that can have children after traversing its children (except the root).
+     * @return A traverser that can be used by the @ref traverse_tree function.
+     */
+    template <typename NodeType, typename... FnArgsTypes>
+    Traverser<NodeType, FnArgsTypes...> make_traverser(typename Traverser<NodeType, FnArgsTypes...>::FnType apply,
+                                                       typename Traverser<NodeType, FnArgsTypes...>::FnType pre = {},
+                                                       typename Traverser<NodeType, FnArgsTypes...>::FnType post = {})
+    {
+        return Traverser<NodeType, FnArgsTypes...>(std::move(apply), std::move(pre), std::move(post));
+    }
+
+    /**
+     * @brief A helper function to traverse a tree.
+     * The apply function is called on every element of the tree except the root, while the pre/post functions are called only on the elements that can have children (except the root).
+     *
+     * @tparam NodeType Type of the nodes of the tree.
+     * @tparam FnArgsTypes The types of arguments that will be passed to the pre/post/apply functions.
+     * @param parent The root of the tree to traverse.
+     * @param traverser The traverser to use, created with the @ref make_traverser function.
+     * @param context The arguments to pass to the pre/post/apply functions.
+     *
+     * @note Currently, argument types must be compatible with universal references. So, it does not works with pointers.
+     */
+    template <typename NodeType, typename... FnArgsTypes>
+    void traverse_tree(NodeType* parent, Traverser<NodeType, FnArgsTypes...>& traverser, FnArgsTypes&&... context)
+    {
+        details::TreeTraverserCaller<NodeType, FnArgsTypes...>::exec(parent, traverser, std::forward<FnArgsTypes>(context)...);
+    }
+}

--- a/spark/patterns/include/spark/patterns/details/Traverser.h
+++ b/spark/patterns/include/spark/patterns/details/Traverser.h
@@ -1,0 +1,43 @@
+#pragma once
+
+namespace spark::patterns::details
+{
+    /**
+     * @brief A generic tree traverser caller that can be used to traverse any @ref Composite.
+     *
+     * This traverser operates on a @ref Composite data structure by recursively traversing its elements and performing designated operations.
+     * To use this, you need to provide a @ref Traverser implementation that defines the pre/post/apply functions.
+     *
+     * The apply function is called on every element of the tree except the root, while the pre/post functions are called only on the elements that can have children.
+     *
+     * @tparam NodeType Type of the nodes of the tree.
+     * @tparam FnArgsTypes The types of arguments that will be passed to the pre/post/apply functions.
+     */
+    template <typename NodeType, typename... FnArgsTypes>
+    class TreeTraverserCaller
+    {
+    public:
+        /**
+         * @brief Traverses the given tree using the given traverser
+         * @param container The tree to visit.
+         * @param traverser The traverser implementation with the pre/post/apply functions.
+         * @param args The arguments to pass to the pre/post/apply functions.
+         */
+        template <typename Traverser>
+        static void exec(NodeType* container, Traverser& traverser, FnArgsTypes&&... args)
+        {
+            for (auto* child : container->getChildren())
+            {
+                if (!child->getChildren().empty())
+                {
+                    auto* sub_container = static_cast<std::conditional_t<std::is_const_v<NodeType>, const NodeType, NodeType>*>(child);
+                    traverser.pre(child, std::forward<FnArgsTypes>(args)...);
+                    traverser.apply(child, std::forward<FnArgsTypes>(args)...);
+                    exec(sub_container, traverser, std::forward<FnArgsTypes>(args)...);
+                    traverser.post(child, std::forward<FnArgsTypes>(args)...);
+                } else
+                    traverser.apply(child, std::forward<FnArgsTypes>(args)...);
+            }
+        }
+    };
+}

--- a/spark/patterns/include/spark/patterns/impl/Composite.h
+++ b/spark/patterns/include/spark/patterns/impl/Composite.h
@@ -54,46 +54,6 @@ namespace spark::patterns
     }
 
     template <typename DerivedType>
-    void Composite<DerivedType>::traverse(std::function<void(DerivedType*)> fn)
-    {
-        for (std::size_t i = 0; i < m_children.size(); ++i)
-        {
-            auto* child = m_children[i];
-            child->traverse(fn);
-        }
-        std::invoke(fn, static_cast<DerivedType*>(this));
-    }
-
-    template <typename DerivedType>
-    void Composite<DerivedType>::traverse(std::function<void(const DerivedType*)> fn) const
-    {
-        for (std::size_t i = 0; i < m_children.size(); ++i)
-        {
-            const auto* child = m_children[i];
-            child->traverse(fn);
-        }
-        std::invoke(fn, static_cast<const DerivedType*>(this));
-    }
-
-    template <typename DerivedType>
-    void Composite<DerivedType>::traverseUp(std::function<void(DerivedType*)> fn)
-    {
-        // Copying the pointer to avoids an overload error with the const version
-        if (auto* parent = m_parent)
-            parent->traverseUp(fn);
-        std::invoke(fn, static_cast<DerivedType*>(this));
-    }
-
-    template <typename DerivedType>
-    void Composite<DerivedType>::traverseUp(std::function<void(const DerivedType*)> fn) const
-    {
-        // Copying the pointer to a const one avoids an overload error with the non-const version
-        if (const auto* parent = m_parent)
-            parent->traverseUp(fn);
-        std::invoke(fn, static_cast<const DerivedType*>(this));
-    }
-
-    template <typename DerivedType>
     void Composite<DerivedType>::add(DerivedType* child)
     {
         auto it = std::ranges::find(m_children, child);

--- a/spark/patterns/tests/CMakeLists.txt
+++ b/spark/patterns/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ spark_add_test_executable(${TARGET_NAME}
         ${SOURCE_DIR}/FactoryTests.cpp
         ${SOURCE_DIR}/SignalTests.cpp
         ${SOURCE_DIR}/SlotTests.cpp
+        ${SOURCE_DIR}/TraverserTests.cpp
 )
 
 target_link_libraries(${TARGET_NAME}

--- a/spark/patterns/tests/src/TraverserTests.cpp
+++ b/spark/patterns/tests/src/TraverserTests.cpp
@@ -1,0 +1,214 @@
+#include "spark/patterns/Traverser.h"
+
+#include "gtest/gtest.h"
+
+namespace spark::patterns::testing
+{
+    class Node final : public Composite<Node>
+    {
+    public:
+        bool touched = false;
+        int touchedIndex = 0;
+
+    public:
+        explicit Node(Node* parent = nullptr) : Composite(parent) {}
+    };
+
+    TEST(TraverserShould, doNothingWithAnEmptyTree)
+    {
+        // Given an empty tree and a dummy traverser
+        Node root;
+        auto traverser = make_traverser<Node, bool&>([](Node*, bool& b) { b = true; });
+
+        // When visiting the tree
+        bool apply_called = false;
+        traverse_tree<Node>(&root, traverser, apply_called);
+
+        // Then nothing happens (no crash, no infinite loop, etc.)
+        ASSERT_FALSE(apply_called);
+    }
+
+    TEST(TraverserShould, callApplyOnAllNodes)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+         *
+         *           Node
+         *         /  |  \
+         *      Node Node Node
+         *                /  \
+         *             Node  Node
+         *              /      \
+         *           Node      Node
+         */
+        Node root;
+        const Node a1(&root);
+        const Node b2(&root);
+        Node a3(&root);
+        Node b1(&a3);
+        const Node c1(&b1);
+        const Node c2(&b1);
+        const Node c3(&b1);
+
+        auto traverser = make_traverser<Node, int&>([](Node*, int& apply) { apply++; });
+
+        // When traversing the tree
+        int apply = 0;
+        traverse_tree<Node>(&root, traverser, apply);
+
+        // Then all nodes are traversed and integer is incremented correctly
+        EXPECT_EQ(apply, 7);
+    }
+
+    TEST(TraverserShould, callPreOnAllGroupsInOrder)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+         *
+         *   Node
+         *    |
+         *   Node
+         *    |
+         *   Node
+         *    |
+         *   Node
+         */
+        Node root;
+        Node a1(&root);
+        Node b1(&a1);
+        const Node c1(&b1);
+
+        int count = 0;
+        auto traverser = make_traverser<Node>([](Node*) {},
+                                              [&count](Node* node)
+                                              {
+                                                  node->touched = true;
+                                                  node->touchedIndex = count++;
+                                              });
+
+        // When traversing the tree
+        traverse_tree<Node>(&root, traverser);
+
+        // Then pre is called on all groups in order
+        EXPECT_TRUE(a1.touched);
+        EXPECT_EQ(a1.touchedIndex, 0);
+        EXPECT_TRUE(b1.touched);
+        EXPECT_EQ(b1.touchedIndex, 1);
+    }
+
+    TEST(TraverserShould, callPostOnAllGroupsInOrder)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+         *
+         *   Node
+         *    |
+         *   Node
+         *    |
+         *   Node
+         *    |
+         *   Node
+         */
+        Node root;
+        Node a1(&root);
+        Node b1(&a1);
+        const Node c1(&b1);
+
+        int count = 0;
+        auto traverser = make_traverser<Node>([](Node*) {},
+                                              [](Node*) {},
+                                              [&count](Node* node)
+                                              {
+                                                  node->touched = true;
+                                                  node->touchedIndex = count++;
+                                              });
+
+        // When traversing the tree
+        traverse_tree<Node>(&root, traverser);
+
+        // Then post is called on all groups in order
+        EXPECT_TRUE(b1.touched);
+        EXPECT_EQ(b1.touchedIndex, 0);
+        EXPECT_TRUE(a1.touched);
+        EXPECT_EQ(a1.touchedIndex, 1);
+    }
+
+    TEST(TraverserShould, callPrePostApplyInOrder)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+        *
+        *   Node
+        *    |
+        *   Node
+        *    |
+        *   Node
+        *    |
+        *   Node
+        */
+        Node root;
+        Node a1(&root);
+        Node b1(&a1);
+        const Node c1(&b1);
+
+        auto traverser = make_traverser<Node, std::stringstream&>([](Node*, std::stringstream& ss) { ss << "apply "; },
+                                                                  [](Node*, std::stringstream& ss) { ss << "pre "; },
+                                                                  [](Node*, std::stringstream& ss) { ss << "post "; });
+
+        // When traversing the tree
+        std::stringstream ss;
+        traverse_tree<Node>(&root, traverser, ss);
+
+        // Then pre, post and apply are called in order
+        EXPECT_EQ(ss.str(), "pre apply pre apply apply post post ");
+    }
+
+    TEST(TraverserShould, traverseAConstTree)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+         *
+         *   Node
+         *    |
+         *   Node
+         *    |
+         *   Node
+         */
+        Node root;
+        Node a1(&root);
+        const Node b1(&a1);
+
+        auto traverser = make_traverser<const Node, std::stringstream&>([](const Node*, std::stringstream& ss) { ss << "apply "; },
+                                                                  [](const Node*, std::stringstream& ss) { ss << "pre "; },
+                                                                  [](const Node*, std::stringstream& ss) { ss << "post "; });
+
+        // When traversing the tree as a const tree
+        std::stringstream ss;
+        [](const Node* c, auto& t, auto& s)
+        {
+            traverse_tree<const Node>(c, t, s);
+        }(&root, traverser, ss);
+
+        // Then pre, post and apply are called in order on the const tree
+        EXPECT_EQ(ss.str(), "pre apply apply post ");
+    }
+
+    TEST(TraverserShould, perfectlyForwardArguments)
+    {
+        /* Given a tree with multiple levels of nodes and a traverser
+         *
+         *   Node
+         *    |
+         *   Node
+         */
+        Node root;
+        const Node a1(&root);
+
+        auto traverser = make_traverser<Node, int&>([](Node*, int& val)
+        {
+            val++;
+        });
+
+        // When traversing the tree
+        int val = 0;
+        traverse_tree<Node, int&>(&root, traverser, val);
+
+        // Then, the given arguments can be modified and keep their fully qualified types
+        EXPECT_EQ(val, 1);
+    }
+}


### PR DESCRIPTION
## Pull Request Template - Spark 

### Description
Replaces the `traverse` and `traverseUp` methods in Composite by an external, non-intrusive version.

### Related Issue
Closes #38 