### PR TITLE
fix-minimized-crash

### DIFF
--- a/spark/core/include/spark/core/Window.h
+++ b/spark/core/include/spark/core/Window.h
@@ -51,6 +51,12 @@ namespace spark::core
         void onUpdate();
 
         /**
+         * \brief Checks if the window is minimized.
+         * \return `true` if the window is minimized, `false` otherwise.
+         */
+        bool isMinimized() const;
+
+        /**
          * \brief Gets the size of the window.
          * \return A 2D vector representing the width and height of the window.
          */

--- a/spark/core/src/Application.cpp
+++ b/spark/core/src/Application.cpp
@@ -74,8 +74,12 @@ namespace spark::core
         while (m_isRunning)
         {
             const float dt = update_timer.restart<std::chrono::seconds>();
+
             // Update
             m_window->onUpdate();
+            if (m_window->isMinimized())
+                continue;
+
             m_scene->onUpdate(dt);
 
             // Render

--- a/spark/core/src/Window.cpp
+++ b/spark/core/src/Window.cpp
@@ -308,13 +308,13 @@ namespace spark::core
         glfwSetWindowSizeCallback(PRIVATE_TO_WINDOW(m_window),
                                   [](GLFWwindow* window, const int width, const int height)
                                   {
-                                      Window & data = *static_cast<Window*>(glfwGetWindowUserPointer(window));
-                                      data.m_settings.size.x = std::max(1, width);
-                                      data.m_settings.size.y = std::max(1, height);
+                                      Window& data = *static_cast<Window*>(glfwGetWindowUserPointer(window));
+                                      data.m_settings.size = { static_cast<unsigned int>(width), static_cast<unsigned int>(height) };
 
                                       events::WindowResizeEvent event(width, height);
                                       data.m_settings.eventCallback(event);
-                                      data.m_renderer->recreateSwapChain(data.m_settings.size);
+                                      if(!data.isMinimized())
+                                        data.m_renderer->recreateSwapChain(data.m_settings.size);
                                   });
 
         glfwSetWindowCloseCallback(PRIVATE_TO_WINDOW(m_window),
@@ -452,6 +452,11 @@ namespace spark::core
     void Window::onUpdate()
     {
         glfwPollEvents();
+    }
+
+    bool Window::isMinimized() const
+    {
+        return m_settings.size.x <= 1 && m_settings.size.y <= 1;
     }
 
     math::Vector2<unsigned int> Window::size() const


### PR DESCRIPTION
## Pull Request Template - Spark 

### Description
When minimizing a window with rendering, the application crashes.

### Related Issue
Closes #76 

### Proposed Changes
Do not render when window is minimized, neither recreate swap chain.